### PR TITLE
unstringify on read

### DIFF
--- a/lib/redis.js
+++ b/lib/redis.js
@@ -273,7 +273,10 @@ BridgeToRedis.prototype.fromDb = function(model, data, fields) {
       delete data[i];
       continue;
     }
-    if (!p[i]) continue;
+    if (!p[i]) {
+      data[i] = JSON.parse(data[i]);
+      continue;
+    }
     if (!data[i]) {
       data[i] = '';
       continue;


### PR DESCRIPTION
### Description
When a model's field has no property definition, we unconditionally stringify the field on write.
If the field data is a string, it gets quoted again. On read we don't undo the stringification.
A string data field becomes a string with extra quotes. read & write need be symmetrical.
#### Related issues
- None

### Checklist
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
